### PR TITLE
Fix default deploy repository to be on github.io

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "github_username": "yourusername",
     "source_repository": "blog_source",
-    "deploy_repository": "{{cookiecutter.github_username}}.github.com",
+    "deploy_repository": "{{cookiecutter.github_username}}.github.io",
     "deploy_directory": "deploy",
     "use_versioning": "y",
     "use_git_flow": "y"


### PR DESCRIPTION
GitHub doesn't allow to create new sites on github.com.
github.io is the correct domain for newly created GitHub Pages sites
since 2016.